### PR TITLE
Fix tests after tokio and http change

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -532,17 +532,16 @@ impl<'u> ClientBuilder<'u> {
 	///
 	/// ```rust,no_run
 	/// # extern crate rand;
-	/// # extern crate tokio_core;
+	/// # extern crate tokio;
 	/// # extern crate futures;
 	/// # extern crate websocket;
 	/// use websocket::ClientBuilder;
 	/// use websocket::futures::{Future, Stream, Sink};
 	/// use websocket::Message;
-	/// use tokio_core::reactor::Core;
+	/// use tokio::reactor::Handle;
 	/// # use rand::Rng;
 	///
 	/// # fn main() {
-	/// let mut core = Core::new().unwrap();
 	///
 	/// // let's randomly do either SSL or plaintext
 	/// let url = if rand::thread_rng().gen() {
@@ -553,14 +552,14 @@ impl<'u> ClientBuilder<'u> {
 	///
 	/// // send a message and hear it come back
 	/// let echo_future = ClientBuilder::new(url).unwrap()
-	///     .async_connect(None, &core.handle())
+	///     .async_connect(None, &Handle::default())
 	///     .and_then(|(s, _)| s.send(Message::text("hallo").into()))
 	///     .and_then(|s| s.into_future().map_err(|e| e.0))
 	///     .map(|(m, _)| {
 	///         assert_eq!(m, Some(Message::text("hallo").into()))
 	///     });
 	///
-	/// core.run(echo_future).unwrap();
+	/// tokio::run(echo_future.map_err(|e| panic!("{}", e)));
 	/// # }
 	/// ```
 	#[cfg(feature = "async-ssl")]
@@ -624,27 +623,25 @@ impl<'u> ClientBuilder<'u> {
 	///# Example
 	///
 	/// ```rust
-	/// # extern crate tokio_core;
+	/// # extern crate tokio;
 	/// # extern crate futures;
 	/// # extern crate websocket;
+	/// use tokio::reactor::Handle;
 	/// use websocket::ClientBuilder;
 	/// use websocket::futures::{Future, Stream, Sink};
 	/// use websocket::Message;
-	/// use tokio_core::reactor::Core;
 	/// # fn main() {
-	///
-	/// let mut core = Core::new().unwrap();
 	///
 	/// // send a message and hear it come back
 	/// let echo_future = ClientBuilder::new("wss://echo.websocket.org").unwrap()
-	///     .async_connect_secure(None, &core.handle())
+	///     .async_connect_secure(None, &Handle::default())
 	///     .and_then(|(s, _)| s.send(Message::text("hallo").into()))
 	///     .and_then(|s| s.into_future().map_err(|e| e.0))
 	///     .map(|(m, _)| {
 	///         assert_eq!(m, Some(Message::text("hallo").into()))
 	///     });
 	///
-	/// core.run(echo_future).unwrap();
+	/// tokio::run(echo_future.map_err(|e| panic!("{}", e)));
 	/// # }
 	/// ```
 	#[cfg(feature = "async-ssl")]
@@ -694,27 +691,25 @@ impl<'u> ClientBuilder<'u> {
 	///# Example
 	///
 	/// ```rust,no_run
-	/// # extern crate tokio_core;
+	/// # extern crate tokio;
 	/// # extern crate futures;
 	/// # extern crate websocket;
+	/// use tokio::reactor::Handle;
 	/// use websocket::ClientBuilder;
 	/// use websocket::futures::{Future, Stream, Sink};
 	/// use websocket::Message;
-	/// use tokio_core::reactor::Core;
 	/// # fn main() {
-	///
-	/// let mut core = Core::new().unwrap();
 	///
 	/// // send a message and hear it come back
 	/// let echo_future = ClientBuilder::new("ws://echo.websocket.org").unwrap()
-	///     .async_connect_insecure(&core.handle())
+	///     .async_connect_insecure(&Handle::default())
 	///     .and_then(|(s, _)| s.send(Message::text("hallo").into()))
 	///     .and_then(|s| s.into_future().map_err(|e| e.0))
 	///     .map(|(m, _)| {
 	///         assert_eq!(m, Some(Message::text("hallo").into()))
 	///     });
 	///
-	/// core.run(echo_future).unwrap();
+	/// tokio::run(echo_future.map_err(|e| panic!("{}", e)));
 	/// # }
 	/// ```
 	#[cfg(feature = "async")]

--- a/src/header/origin.rs
+++ b/src/header/origin.rs
@@ -97,13 +97,13 @@ impl fmt::Display for Origin {
 #[cfg(all(feature = "nightly", test))]
 mod tests {
 	use super::*;
-	use hyper::header::Header;
+	use http::header::Header;
 	use test;
 	#[test]
 	fn test_header_origin() {
 		use header::Headers;
 
-		let origin = Origin("foo bar".to_string());
+		let origin = Origin::from_str("foo bar");
 		let mut headers = Headers::new();
 		headers.set(origin);
 

--- a/src/header/sec_websocket_accept.rs
+++ b/src/header/sec_websocket_accept.rs
@@ -97,7 +97,7 @@ mod tests {
 	#[test]
 	fn test_header_accept() {
 		let key = FromStr::from_str("dGhlIHNhbXBsZSBub25jZQ==").unwrap();
-		let accept = WebSocketAccept::new(&key);
+		let accept = WebSocketAccept::new(key);
 		let mut headers = Headers::new();
 		headers.set(accept);
 
@@ -110,7 +110,7 @@ mod tests {
 	fn bench_header_accept_new(b: &mut test::Bencher) {
 		let key = WebSocketKey::new();
 		b.iter(|| {
-			let mut accept = WebSocketAccept::new(&key);
+			let mut accept = WebSocketAccept::new(key);
 			test::black_box(&mut accept);
 		});
 	}
@@ -118,14 +118,14 @@ mod tests {
 	fn bench_header_accept_parse(b: &mut test::Bencher) {
 		let value = vec![b"s3pPLMBiTxaQ9kYGzzhZRbK+xOo=".to_vec()];
 		b.iter(|| {
-			let mut accept: WebSocketAccept = Header::parse_header(&value[..]).unwrap();
+			let mut accept = Header::parse_header(&value[..]).unwrap();
 			test::black_box(&mut accept);
 		});
 	}
 	#[bench]
 	fn bench_header_accept_format(b: &mut test::Bencher) {
 		let value = vec![b"s3pPLMBiTxaQ9kYGzzhZRbK+xOo=".to_vec()];
-		let val: WebSocketAccept = Header::parse_header(&value[..]).unwrap();
+		let val = Header::parse_header(&value[..]).unwrap();
 		b.iter(|| {
 			format!("{}", val.serialize());
 		});

--- a/src/header/sec_websocket_extensions.rs
+++ b/src/header/sec_websocket_extensions.rs
@@ -151,7 +151,7 @@ impl fmt::Display for WebSocketExtensions {
 #[cfg(all(feature = "nightly", test))]
 mod tests {
 	use super::*;
-	use hyper::header::Header;
+	use http::header::Header;
 	use test;
 	#[test]
 	fn test_header_extensions() {

--- a/src/header/sec_websocket_protocol.rs
+++ b/src/header/sec_websocket_protocol.rs
@@ -42,7 +42,7 @@ impl fmt::Display for WebSocketProtocol {
 #[cfg(all(feature = "nightly", test))]
 mod tests {
 	use super::*;
-	use hyper::header::Header;
+	use http::header::Header;
 	use test;
 	#[test]
 	fn test_header_protocol() {

--- a/src/header/sec_websocket_version.rs
+++ b/src/header/sec_websocket_version.rs
@@ -53,7 +53,7 @@ impl fmt::Display for WebSocketVersion {
 #[cfg(all(feature = "nightly", test))]
 mod tests {
 	use super::*;
-	use hyper::header::Header;
+	use http::header::Header;
 	use test;
 	#[test]
 	fn test_websocket_version() {


### PR DESCRIPTION
- Replace core.run with tokio::run
- Fix move of http module from hyper to http crate.