### PR TITLE
Bump tokio-tls to 0.2 and native-tls to ^0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,11 @@ base64 = "0.5"
 http = "0.1.5"
 tokio = { version = "0.1.4", optional = true }
 tokio-io = { version = "0.1.6", optional = true }
+tokio-tls = { version = "0.2", optional = true }
 futures = { version = "0.1.19", optional = true }
 bytes = { version = "0.4", optional = true }
-native-tls = { version = "^0.1.2", optional = true }
+native-tls = { version = "^0.2.1", optional = true }
 hyper = "0.12.0"
-
-[dependencies.tokio-tls]
-git = "https://github.com/enzious/tokio-tls"
-optional = true
 
 [dev-dependencies]
 futures-cpupool = "0.1"

--- a/src/result.rs
+++ b/src/result.rs
@@ -140,7 +140,7 @@ impl<T> From<TlsHandshakeError<T>> for WebSocketError {
 	fn from(err: TlsHandshakeError<T>) -> WebSocketError {
 		match err {
 			TlsHandshakeError::Failure(_) => WebSocketError::TlsHandshakeFailure,
-			TlsHandshakeError::Interrupted(_) => WebSocketError::TlsHandshakeInterruption,
+			TlsHandshakeError::WouldBlock(_) => WebSocketError::TlsHandshakeInterruption,
 		}
 	}
 }

--- a/src/server/async.rs
+++ b/src/server/async.rs
@@ -11,9 +11,9 @@ use bytes::BytesMut;
 pub use tokio::reactor::Handle;
 
 #[cfg(any(feature = "async-ssl"))]
-use native_tls::TlsAcceptor;
+use tokio_tls::TlsAcceptor;
 #[cfg(any(feature = "async-ssl"))]
-use tokio_tls::{TlsAcceptorExt, TlsStream};
+use tokio_tls::TlsStream;
 
 /// The asynchronous specialization of a websocket server.
 /// Use this struct to create asynchronous servers.
@@ -128,7 +128,7 @@ impl WsServer<TlsAcceptor, TcpListener> {
 		})
 		                 .and_then(move |stream| {
 			let a = stream.local_addr().unwrap();
-			acceptor.accept_async(stream)
+			acceptor.accept(stream)
 			        .map_err(|e| {
 				InvalidConnection {
 					stream: None,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,11 @@
 //! Provides an implementation of a WebSocket server
-#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
+#[cfg(any(feature = "sync-ssl"))]
 use native_tls::TlsAcceptor;
+
+#[cfg(feature = "async-ssl")]
+mod async_imports {
+	pub use tokio_tls::TlsAcceptor;
+}
 
 use codec::http::RequestHead;
 use stream::Stream;
@@ -23,8 +28,11 @@ pub struct NoTlsAcceptor;
 /// is running over SSL or not.
 pub trait OptionalTlsAcceptor {}
 impl OptionalTlsAcceptor for NoTlsAcceptor {}
-#[cfg(any(feature = "sync-ssl", feature = "async-ssl"))]
+#[cfg(any(feature = "sync-ssl"))]
 impl OptionalTlsAcceptor for TlsAcceptor {}
+
+#[cfg(any(feature = "async-ssl"))]
+impl OptionalTlsAcceptor for async_imports::TlsAcceptor {}
 
 /// When a sever tries to accept a connection many things can go wrong.
 ///

--- a/src/server/sync.rs
+++ b/src/server/sync.rs
@@ -112,7 +112,7 @@ impl WsServer<TlsAcceptor, TcpListener> {
 	/// use std::fs::File;
 	/// use websocket::Message;
 	/// use websocket::sync::Server;
-	/// use native_tls::{Pkcs12, TlsAcceptor};
+	/// use native_tls::{Identity, TlsAcceptor};
 	///
 	/// // In this example we retrieve our keypair and certificate chain from a PKCS #12 archive,
 	/// // but but they can also be retrieved from, for example, individual PEM- or DER-formatted
@@ -120,9 +120,9 @@ impl WsServer<TlsAcceptor, TcpListener> {
 	/// let mut file = File::open("identity.pfx").unwrap();
 	/// let mut pkcs12 = vec![];
 	/// file.read_to_end(&mut pkcs12).unwrap();
-	/// let pkcs12 = Pkcs12::from_der(&pkcs12, "hacktheplanet").unwrap();
+	/// let pkcs12 = Identity::from_pkcs12(&pkcs12, "hacktheplanet").unwrap();
 	///
-	/// let acceptor = TlsAcceptor::builder(pkcs12).unwrap().build().unwrap();
+	/// let acceptor = TlsAcceptor::builder(pkcs12).build().unwrap();
 	///
 	/// let server = Server::bind_secure("127.0.0.1:1234", acceptor).unwrap();
 	///


### PR DESCRIPTION
This bumps tokio-tls to `0.2` and native-tls to `^0.2.1`. 

I am assuming that the latest version of `tokio-tls` also covers your changes in enzious/tokio-tls.